### PR TITLE
page scaling fix

### DIFF
--- a/websrc/src/components/App.scss
+++ b/websrc/src/components/App.scss
@@ -61,7 +61,7 @@ input, select {
   height: 100vh;
   max-width: 100vw;
   max-height: 100vh;
-  overflow: hidden;
+  overflow: scroll;
 
   .jumbo {
     h1 {


### PR DESCRIPTION
Fix for [Can't reach "continue" button](https://github.com/luxonis/blobconverter/issues/3).
Tested on chrome, firefox and brave.