### PR TITLE
Modify generated .blob file to include OpenVINO version number

### DIFF
--- a/main.py
+++ b/main.py
@@ -290,8 +290,13 @@ def compile():
             for command in commands:
                 env.run_command(command)
 
-    with open(out_path, 'rb') as f:
-        bucket.put_object(Body=f.read(), Key='{}.blob'.format(req_hash))
+            major, minor = env.version.replace('_R3', '').split('.')
+            with open(out_path, 'rb+') as f:
+                f.seek(60)
+                f.write(bytes([int(part) for part in major]))
+                f.write(bytes([0, 0, 0, int(minor)]))
+                f.seek(0)
+                bucket.put_object(Body=f.read(), Key='{}.blob'.format(req_hash))
 
     @after_this_request
     def remove_dir(response):


### PR DESCRIPTION
This PR modifies the generated blob files to contain the version number (major & minor) of the OpenVINO toolkit used to compile it.
It modifies bytes 60-63 for the major and bytes 64-67 for the minor part of the version. Here is a generated blobfile's hexdump after modification

```
$ hexdump -n 70 -C /home/vandavv/.cache/blobconverter/face-detection-retail-0004_openvino_2021.3_3shave.blob
00000000  7f 65 6c 66 00 00 00 00  00 00 00 00 00 00 00 00  |.elf............|
00000010  01 00 02 00 02 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 00 00 00 00  a0 01 00 00 00 00 00 00  |................|
00000030  00 00 00 00 ed 25 00 00  c0 aa 14 00 02 00 02 01  |.....%..........|
00000040  00 00 00 03 01 00                                 |......|
00000046
```

(Last four bytes in line `00000030` specify the major version, with `02 00 02 01` being 2021, whereas the first four bytes in line `00000040`, with `00 00 00 03` being 3, so the blob was compiled against 2021.3 version)
