### PR TITLE
Add --download-ir and download_ir option

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -11,9 +11,9 @@ python3 -m pip install blobconverter
 ## Usage
 
 ```
-usage: blobconverter [-h] [-zn ZOO_NAME] [-cp CAFFE_PROTO] [-cm CAFFE_MODEL] [-tf TENSORFLOW_PB] [-ox OPENVINO_XML] [-ob OPENVINO_BIN]
-                     [-rawn RAW_NAME] [-rawc RAW_CONFIG] [-sh {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}] [-dt DATA_TYPE] [-o OUTPUT_DIR]
-                     [-v VERSION] [--optimizer-params OPTIMIZER_PARAMS] [--compile-params COMPILE_PARAMS] [--converter-url URL] [--no-cache]
+usage: __main__.py [-h] [-zn ZOO_NAME] [-cp CAFFE_PROTO] [-cm CAFFE_MODEL] [-tf TENSORFLOW_PB] [-ox OPENVINO_XML] [-ob OPENVINO_BIN] [-rawn RAW_NAME] [-rawc RAW_CONFIG] [-sh {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}]
+                   [-dt DATA_TYPE] [-o OUTPUT_DIR] [-v VERSION] [--optimizer-params OPTIMIZER_PARAMS] [--compile-params COMPILE_PARAMS] [--converter-url URL] [--no-cache] [--zoo-list] [--download-ir]
+
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -48,6 +48,8 @@ optional arguments:
   --converter-url URL   URL to BlobConverter API endpoint used for conversion
   --no-cache            Omit .cache directory and force new compilation of the blob
   --zoo-list            List all models available in OpenVINO Model Zoo
+  --download-ir         Downloads OpenVINO IR files used to compile the blob. Result path points to a result ZIP archive
+
 
 ```
 

--- a/cli/blobconverter/__init__.py
+++ b/cli/blobconverter/__init__.py
@@ -171,7 +171,7 @@ def __download_from_response(resp, fpath: Path):
 
 
 def compile_blob(blob_name, version=None, shaves=None, req_data=None, req_files=None, output_dir=None, url=None,
-                  use_cache=True, compile_params=None, data_type=None):
+                  use_cache=True, compile_params=None, data_type=None, download_ir=False):
     if shaves is None:
         shaves = __defaults["shaves"]
     if url is None:
@@ -204,6 +204,7 @@ def compile_blob(blob_name, version=None, shaves=None, req_data=None, req_files=
         "myriad_shaves": str(shaves),
         "myriad_params_advanced": ' '.join(compile_params),
         "data_type": data_type,
+        "download_ir": download_ir,
         **req_data,
     }
 
@@ -252,6 +253,8 @@ def compile_blob(blob_name, version=None, shaves=None, req_data=None, req_files=
     response.raise_for_status()
 
     blob_path.parent.mkdir(parents=True, exist_ok=True)
+    if download_ir:
+        blob_path = blob_path.with_suffix('.zip')
     __download_from_response(response, blob_path)
 
     return blob_path
@@ -395,6 +398,7 @@ def __run_cli__():
     parser.add_argument('--converter-url', dest="url", help="URL to BlobConverter API endpoint used for conversion")
     parser.add_argument('--no-cache', dest="use_cache", action="store_false", help="Omit .cache directory and force new compilation of the blob")
     parser.add_argument('--zoo-list', action="store_true", help="List all models available in OpenVINO Model Zoo")
+    parser.add_argument('--download-ir', action="store_true", help="Downloads OpenVINO IR files used to compile the blob. Result path points to a result ZIP archive")
 
     args = parser.parse_args()
 
@@ -402,7 +406,7 @@ def __run_cli__():
 
     common_args = {
         arg: getattr(args, arg)
-        for arg in ["shaves", "data_type", "output_dir", "version", "url", "compile_params"]
+        for arg in ["shaves", "data_type", "output_dir", "version", "url", "compile_params", "download_ir"]
     }
     if args.zoo_list:
         return zoo_list()

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='blobconverter',
-    version='0.0.10',
+    version='0.0.11',
     description='The tool that allows you to covert neural networks to MyriadX blob',
     long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR enables the download of OpenVINO IR files along with the blob itself. Since HTTP protocol was designed to send one file per one request, I create a ZIP archive where I put both IR files and the output blob.

Can be tested using
```
import blobconverter

result = blobconverter.from_zoo(
    name="face-detection-retail-0004",
    shaves=3,
    download_ir=True
)
print(result)
```
or
```
python -m blobconverter --zoo-name face-detection-retail-0004 --shaves 6 --download-ir
```