### PR TITLE
Remove bloating warning message from stdout

### DIFF
--- a/cli/blobconverter/__init__.py
+++ b/cli/blobconverter/__init__.py
@@ -198,7 +198,7 @@ def compile_blob(blob_name, version=None, shaves=None, req_data=None, req_files=
         cache_config = {}
 
     url_params = {
-        'version': version
+        'version': version,
     }
     data = {
         "myriad_shaves": str(shaves),
@@ -229,8 +229,9 @@ def compile_blob(blob_name, version=None, shaves=None, req_data=None, req_files=
     with cache_config_path.open('w') as f:
         json.dump(new_cache_config, f)
     try:
-        __download_from_s3_bucket("{}.blob".format(req_hash), blob_path)
-        return blob_path
+        if not download_ir:
+            __download_from_s3_bucket("{}.blob".format(req_hash), blob_path)
+            return blob_path
     except botocore.exceptions.ClientError as ex:
         if ex.response['Error']['Code'] not in ('NoSuchKey', '404'):
             raise ex

--- a/main.py
+++ b/main.py
@@ -98,11 +98,16 @@ class EnvResolver:
             stdout, stderr = proc.communicate()
             print("Command returned exit code: {}".format(proc.returncode))
             if proc.returncode != 0:
+                filtered_stdout = "\n".join(filter(
+                    lambda line: "[myriad_compile] usb_find_device_with_bcd:266\tLibrary has not been initialized when loaded" not in line,
+                    stdout.decode().split("\n")
+                ))
+                print(filtered_stdout.split("\n"))
                 raise CommandFailed(
                     message=f"Command failed with exit code {proc.returncode}, command: {command}",
                     payload=dict(
                         stderr=stderr.decode(),
-                        stdout=stdout.decode(),
+                        stdout=filtered_stdout,
                         exit_code=proc.returncode
                     )
                 )


### PR DESCRIPTION
Added filtering for bloating message

```
: [xLinkUsb] [    645631] [myriad_compile] usb_find_device_with_bcd:266	Library has not been initialized when loaded
```

Per discussion here - https://discuss.luxonis.com/d/225-unable-to-convert-segmentation-model-using-blobconverter/2

Testable by trying to compile `instance-segmentation-security-1040`, on master it caused a client crash and now it shows a correct error modal
![demo](https://i.imgur.com/y2ubcQr.png)