### PR TITLE
Fix issue with missing bucket in certain regions

### DIFF
--- a/cli/blobconverter/__init__.py
+++ b/cli/blobconverter/__init__.py
@@ -97,14 +97,14 @@ __defaults = {
     "silent": False,
 }
 try:
-    bucket = boto3\
-        .resource('s3', config=botocore.client.Config(signature_version=botocore.UNSIGNED))\
-        .Bucket('blobconverter')
+    s3 = boto3.resource('s3', config=botocore.client.Config(signature_version=botocore.UNSIGNED))
+    bucket = s3.Bucket('blobconverter')
+    s3.meta.client.head_bucket(Bucket=bucket.name)
 except botocore.exceptions.EndpointConnectionError:
     # region must be pinned to prevent boto3 specifying a bucket/region that doesn't exist
-    bucket = boto3\
-        .resource('s3', config=botocore.client.Config(signature_version=botocore.UNSIGNED), region_name='us-east-1')\
-        .Bucket('blobconverter')
+    s3 = boto3.resource('s3', config=botocore.client.Config(signature_version=botocore.UNSIGNED), region_name='us-east-1')
+    bucket = s3.Bucket('blobconverter')
+    s3.meta.client.head_bucket(Bucket=bucket.name)
 
 
 def set_defaults(url=None, version=None, shaves=None, output_dir=None, compile_params: list = None,

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='blobconverter',
-    version='0.0.11',
+    version='0.0.12',
     description='The tool that allows you to covert neural networks to MyriadX blob',
     long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR resolves #17. During bucket initialization, the connection is being tested and if it fails, a fixed region is applied to override default assignment from boto3