### PR TITLE
Add DepthAI model zoo and URL parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ COPY --from=openvino/ubuntu18_dev:2020.1 /opt/intel/openvino /opt/intel/openvino
 COPY --from=openvino/ubuntu18_dev:2019_R3.1 /opt/intel/openvino /opt/intel/openvino2019_3
 
 USER root
-RUN apt-get update && apt-get -y upgrade
+RUN apt-get update && apt-get -y upgrade && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update
 RUN apt-get install -y python3-dev nano git git-lfs python3.7
 WORKDIR /app
 RUN chown openvino:openvino /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=openvino/ubuntu18_dev:2019_R3.1 /opt/intel/openvino /opt/intel/openv
 
 USER root
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y python3-dev nano git git-lfs python3.7 python3.7-dev
+RUN apt-get install -y python3-dev nano git git-lfs python3.7
 WORKDIR /app
 RUN chown openvino:openvino /app
 USER openvino

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR websrc/
 RUN yarn
 RUN yarn build
 
-FROM openvino/ubuntu18_dev:2021.4
+FROM openvino/ubuntu20_dev:2021.4
 
-COPY --from=openvino/ubuntu18_dev:2021.3 /opt/intel/openvino /opt/intel/openvino2021_3
+COPY --from=openvino/ubuntu20_dev:2021.3 /opt/intel/openvino /opt/intel/openvino2021_3
 COPY --from=openvino/ubuntu18_dev:2021.2 /opt/intel/openvino /opt/intel/openvino2021_2
 COPY --from=openvino/ubuntu18_dev:2021.1 /opt/intel/openvino /opt/intel/openvino2021_1
 COPY --from=openvino/ubuntu18_dev:2020.4 /opt/intel/openvino /opt/intel/openvino2020_4

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ USER root
 RUN apt-get update && apt-get -y upgrade && apt-get install -y software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update
-RUN apt-get install -y python3-dev nano git git-lfs python3.7
+RUN apt-get install -y python3-dev nano git git-lfs python3.7 python3.7-venv
 WORKDIR /app
 RUN chown openvino:openvino /app
 USER openvino

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ USER openvino
 ENV PYTHONUNBUFFERED 1
 
 RUN git lfs install
-RUN git clone https://github.com/luxonis/depthai-model-zoo.git
+RUN git clone --branch specify_precision https://github.com/luxonis/depthai-model-zoo.git
 
 ADD setup_container.py .
 RUN python3 setup_container.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=openvino/ubuntu18_dev:2019_R3.1 /opt/intel/openvino /opt/intel/openv
 
 USER root
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y python-dev python3-dev nano git git-lfs
+RUN apt-get install -y python3-dev nano git git-lfs python3.7 python3.7-dev
 WORKDIR /app
 RUN chown openvino:openvino /app
 USER openvino

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,14 @@ COPY --from=openvino/ubuntu18_dev:2019_R3.1 /opt/intel/openvino /opt/intel/openv
 
 USER root
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y python-dev python3-dev nano
+RUN apt-get install -y python-dev python3-dev nano git git-lfs
 WORKDIR /app
 RUN chown openvino:openvino /app
 USER openvino
 ENV PYTHONUNBUFFERED 1
+
+RUN git lfs install
+RUN git clone https://github.com/luxonis/depthai-model-zoo.git
 
 ADD setup_container.py .
 RUN python3 setup_container.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ USER openvino
 ENV PYTHONUNBUFFERED 1
 
 RUN git lfs install
-RUN git clone --branch specify_precision https://github.com/luxonis/depthai-model-zoo.git
+RUN git clone https://github.com/luxonis/depthai-model-zoo.git
 
 ADD setup_container.py .
 RUN python3 setup_container.py

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,14 +11,16 @@ python3 -m pip install blobconverter
 ## Usage
 
 ```
-usage: blobconverter [-h] [-zn ZOO_NAME] [-onnx ONNX_MODEL] [-cp CAFFE_PROTO] [-cm CAFFE_MODEL] [-tf TENSORFLOW_PB] [-ox OPENVINO_XML] [-ob OPENVINO_BIN] [-rawn RAW_NAME]
-                     [-rawc RAW_CONFIG] [-sh {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}] [-dt DATA_TYPE] [-o OUTPUT_DIR] [-v VERSION] [--optimizer-params OPTIMIZER_PARAMS]
-                     [--compile-params COMPILE_PARAMS] [--converter-url URL] [--no-cache] [--zoo-list] [--download-ir]
+usage: blobconverter [-h] [-zn ZOO_NAME] [-zt ZOO_TYPE] [-onnx ONNX_MODEL] [-cp CAFFE_PROTO] [-cm CAFFE_MODEL] [-tf TENSORFLOW_PB] [-ox OPENVINO_XML] [-ob OPENVINO_BIN]
+                     [-rawn RAW_NAME] [-rawc RAW_CONFIG] [-sh {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}] [-dt DATA_TYPE] [-o OUTPUT_DIR] [-v VERSION]
+                     [--optimizer-params OPTIMIZER_PARAMS] [--compile-params COMPILE_PARAMS] [--converter-url URL] [--no-cache] [--zoo-list] [--download-ir]
 
 optional arguments:
   -h, --help            show this help message and exit
   -zn ZOO_NAME, --zoo-name ZOO_NAME
                         Name of a model to download from OpenVINO Model Zoo
+  -zt ZOO_TYPE, --zoo-type ZOO_TYPE
+                        Type of the model zoo to use, available: "intel", "depthai"
   -onnx ONNX_MODEL, --onnx-model ONNX_MODEL
                         Path to ONNX .onnx file
   -cp CAFFE_PROTO, --caffe-proto CAFFE_PROTO
@@ -191,5 +193,27 @@ blob_path = blobconverter.from_config(
     path="/path/to/model.yml",
     data_type="FP16",
     shaves=5,
+)
+```
+
+### Use [DepthAI Model Zoo](https://github.com/luxonis/depthai-model-zoo) to download files
+
+```python
+import blobconverter
+
+blob_path = blobconverter.from_zoo(name="megadepth", zoo_type="depthai")
+```
+
+### Download using URLs instead of local files
+```python
+import blobconverter
+
+blob_path = blobconverter.from_openvino(
+    xml="https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml",
+    xml_size=31526,
+    xml_sha256="54d62ce4a3c3d7f1559a22ee9524bac41101103a8dceaabec537181995eda655",
+    bin="https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin",
+    bin_size=4276038,
+    bin_sha256="3586df5340e9fcd73ba0e2d802631bd9e027179490635c03b273d33d582e2b58"
 )
 ```

--- a/cli/blobconverter/__init__.py
+++ b/cli/blobconverter/__init__.py
@@ -55,7 +55,7 @@ class ConfigBuilder:
 
     def with_file(self, name, path=None, url=None, google_drive=None, size=None, sha256=None):
         file_entry = {
-            "name": "{}".format(name),
+            "name": "{}/{}".format(self.precision, name),
         }
 
         if path is not None:
@@ -309,8 +309,8 @@ def from_caffe(proto, model, data_type=None, optimizer_params=None, proto_size=N
         .framework("caffe") \
         .model_optimizer_args(optimizer_params + [
             "--data_type={}".format(data_type),
-            "--input_model=$dl_dir/{}".format(model_name),
-            "--input_proto=$dl_dir/{}".format(proto_name),
+            "--input_model=$dl_dir/{}/{}".format(data_type, model_name),
+            "--input_proto=$dl_dir/{}/{}".format(data_type, proto_name),
         ])
 
     if str(proto).startswith("http"):
@@ -343,7 +343,7 @@ def from_onnx(model, data_type=None, optimizer_params=None, model_size=None, mod
         .framework("onnx")\
         .model_optimizer_args(optimizer_params + [
             "--data_type={}".format(data_type),
-            "--input_model=$dl_dir/{}".format(model_name),
+            "--input_model=$dl_dir/{}/{}".format(data_type, model_name),
         ])
 
     if str(model).startswith("http"):
@@ -372,7 +372,7 @@ def from_tf(frozen_pb, data_type=None, optimizer_params=None, frozen_pb_size=Non
         .framework("tf")\
         .model_optimizer_args(optimizer_params + [
             "--data_type={}".format(data_type),
-            "--input_model=$dl_dir/{}".format(data_type, frozen_pb_name),
+            "--input_model=$dl_dir/{}/{}".format(data_type, frozen_pb_name),
         ])
 
     if str(frozen_pb).startswith("http"):

--- a/cli/blobconverter/__init__.py
+++ b/cli/blobconverter/__init__.py
@@ -55,7 +55,7 @@ class ConfigBuilder:
 
     def with_file(self, name, path=None, url=None, google_drive=None, size=None, sha256=None):
         file_entry = {
-            "name": "{}/{}".format(self.precision, name),
+            "name": "{}".format(name),
         }
 
         if path is not None:
@@ -309,8 +309,8 @@ def from_caffe(proto, model, data_type=None, optimizer_params=None, proto_size=N
         .framework("caffe") \
         .model_optimizer_args(optimizer_params + [
             "--data_type={}".format(data_type),
-            "--input_model=$dl_dir/{}/{}".format(data_type, model_name),
-            "--input_proto=$dl_dir/{}/{}".format(data_type, proto_name),
+            "--input_model=$dl_dir/{}".format(model_name),
+            "--input_proto=$dl_dir/{}".format(proto_name),
         ])
 
     if str(proto).startswith("http"):
@@ -343,7 +343,7 @@ def from_onnx(model, data_type=None, optimizer_params=None, model_size=None, mod
         .framework("onnx")\
         .model_optimizer_args(optimizer_params + [
             "--data_type={}".format(data_type),
-            "--input_model=$dl_dir/{}/{}".format(data_type, model_name),
+            "--input_model=$dl_dir/{}".format(model_name),
         ])
 
     if str(model).startswith("http"):
@@ -372,7 +372,7 @@ def from_tf(frozen_pb, data_type=None, optimizer_params=None, frozen_pb_size=Non
         .framework("tf")\
         .model_optimizer_args(optimizer_params + [
             "--data_type={}".format(data_type),
-            "--input_model=$dl_dir/{}/{}".format(data_type, frozen_pb_name),
+            "--input_model=$dl_dir/{}".format(data_type, frozen_pb_name),
         ])
 
     if str(frozen_pb).startswith("http"):

--- a/cli/blobconverter/__init__.py
+++ b/cli/blobconverter/__init__.py
@@ -276,7 +276,7 @@ def compile_blob(blob_name, version=None, shaves=None, req_data=None, req_files=
         try:
             print(json.dumps(response.json(), indent=4))
         except:
-            pass
+            print(response.text)
     response.raise_for_status()
 
     blob_path.parent.mkdir(parents=True, exist_ok=True)

--- a/cli/blobconverter/test.py
+++ b/cli/blobconverter/test.py
@@ -12,6 +12,16 @@ if not use_cache and Path(blobconverter.__defaults["output_dir"]).exists():
 result = blobconverter.from_zoo(name="megadepth", zoo_type="depthai")
 print(result)
 
+result = blobconverter.from_openvino(
+    xml="https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml",
+    xml_size=31526,
+    xml_sha256="54d62ce4a3c3d7f1559a22ee9524bac41101103a8dceaabec537181995eda655",
+    bin="https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin",
+    bin_size=4276038,
+    bin_sha256="3586df5340e9fcd73ba0e2d802631bd9e027179490635c03b273d33d582e2b58"
+)
+print(result)
+
 result = blobconverter.from_onnx(
     model="../../concat.onnx",
     shaves=3,

--- a/cli/blobconverter/test.py
+++ b/cli/blobconverter/test.py
@@ -9,6 +9,8 @@ use_cache = False
 if not use_cache and Path(blobconverter.__defaults["output_dir"]).exists():
     shutil.rmtree(blobconverter.__defaults["output_dir"])
 
+result = blobconverter.from_zoo(name="megadepth", zoo_type="depthai")
+print(result)
 
 result = blobconverter.from_onnx(
     model="../../concat.onnx",

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='blobconverter',
-    version='1.1.1',
+    version='1.2.0',
     description='The tool that allows you to covert neural networks to MyriadX blob',
     long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/main.py
+++ b/main.py
@@ -251,7 +251,6 @@ def compile():
     use_zoo = request.form.get('use_zoo', False)
     data_type = request.form.get('data_type', "FP16")
     download_ir = request.form.get('download_ir', "false").lower() == "true"
-    xml_path = next(env.workdir.rglob(f"**/{name}.xml"), None)
 
     if config_file is None:
         if use_zoo:
@@ -294,6 +293,7 @@ def compile():
             f"{env.executable} {env.converter_path} --precisions {data_type} --output_dir {env.workdir} --download_dir {env.workdir} --name {name} --model_root {env.workdir}"
         )
 
+    xml_path = next(env.workdir.rglob(f"**/{name}.xml"), None)
     out_path = xml_path.with_suffix('.blob')
     out_path.parent.mkdir(parents=True, exist_ok=True)
     commands.append(f"{env.compiler_path} -m {xml_path} -o {out_path} -c {compile_config_path} {myriad_params_advanced}")

--- a/main.py
+++ b/main.py
@@ -251,7 +251,6 @@ def compile():
     use_zoo = request.form.get('use_zoo', False)
     data_type = request.form.get('data_type', "FP16")
     download_ir = request.form.get('download_ir', "false").lower() == "true"
-
     if config_file is None:
         if use_zoo:
             zoo_path = fetch_from_zoo(env, name)
@@ -278,6 +277,7 @@ def compile():
     config = parse_config(config_path, name, data_type, env)
     compile_config_path = prepare_compile_config(myriad_shaves, env)
     commands = []
+    xml_path = env.workdir / name / data_type / (name + ".xml")
     if use_zoo:
         commands.append(
             f"{env.executable} {env.downloader_path} --output_dir {env.workdir} --cache_dir {env.cache_path} --num_attempts 5 --name {name} --model_root {env.workdir}"
@@ -293,7 +293,6 @@ def compile():
             f"{env.executable} {env.converter_path} --precisions {data_type} --output_dir {env.workdir} --download_dir {env.workdir} --name {name} --model_root {env.workdir}"
         )
 
-    xml_path = env.workdir / name / (name + ".xml")
     out_path = xml_path.with_suffix('.blob')
     out_path.parent.mkdir(parents=True, exist_ok=True)
     commands.append(f"{env.compiler_path} -m {xml_path} -o {out_path} -c {compile_config_path} {myriad_params_advanced}")

--- a/main.py
+++ b/main.py
@@ -278,12 +278,13 @@ def compile():
     compile_config_path = prepare_compile_config(myriad_shaves, env)
     commands = []
     xml_path = env.workdir / name / data_type / (name + ".xml")
-    if use_zoo:
+    if len(file_paths) == 0:
         commands.append(
             f"{env.executable} {env.downloader_path} --output_dir {env.workdir} --cache_dir {env.cache_path} --num_attempts 5 --name {name} --model_root {env.workdir}"
         )
-        preconvert_script = env.model_zoo_path / "public" / name / "pre-convert.py"
-        if preconvert_script.exists():
+    if use_zoo:
+        preconvert_script = next(env.model_zoo_path.rglob(f"**/{name}/pre-convert.py"), None)
+        if preconvert_script is not None:
             commands.append(
                 f"{env.executable} {preconvert_script} {env.workdir / name} {env.workdir / name}"
             )

--- a/main.py
+++ b/main.py
@@ -236,7 +236,7 @@ def prepare_compile_config(shaves, env):
 
 
 def fetch_from_zoo(env, name):
-    return next(env.model_zoo_path.rglob(f'*/{name}/model.yml'), None)
+    return next(env.model_zoo_path.rglob(f'**/{name}/model.yml'), None)
 
 
 @app.route("/compile", methods=['POST'])

--- a/main.py
+++ b/main.py
@@ -251,6 +251,8 @@ def compile():
     use_zoo = request.form.get('use_zoo', False)
     data_type = request.form.get('data_type', "FP16")
     download_ir = request.form.get('download_ir', "false").lower() == "true"
+    xml_path = next(env.workdir.rglob(f"**/{name}.xml"), None)
+
     if config_file is None:
         if use_zoo:
             zoo_path = fetch_from_zoo(env, name)
@@ -277,7 +279,6 @@ def compile():
     config = parse_config(config_path, name, data_type, env)
     compile_config_path = prepare_compile_config(myriad_shaves, env)
     commands = []
-    xml_path = env.workdir / name / data_type / (name + ".xml")
     if use_zoo:
         commands.append(
             f"{env.executable} {env.downloader_path} --output_dir {env.workdir} --cache_dir {env.cache_path} --num_attempts 5 --name {name} --model_root {env.workdir}"

--- a/main.py
+++ b/main.py
@@ -82,14 +82,21 @@ class EnvResolver:
             self.downloader_path = Path(__file__).parent / Path("model_compiler/openvino_2019.3/downloader.py")
             self.venv_path = Path(__file__).parent / Path("venvs/venv2019_3")
         else:
-            raise ValueError(f'Unknown self.version: "{self.version}", available: "2021.4", "2021.3", "2021.2", "2021.1", "2020.4", "2020.3", "2020.2", "2020.1", "2019.R3"')
+            raise ValueError(f'Unknown version: "{self.version}", available: "2021.4", "2021.3", "2021.2", "2021.1", "2020.4", "2020.3", "2020.2", "2020.1", "2019.R3"')
 
         self.workdir = UPLOAD_FOLDER / Path(uuid.uuid4().hex)
         self.workdir.mkdir(parents=True, exist_ok=True)
         self.cache_path.mkdir(parents=True, exist_ok=True)
 
         self.compiler_path = self.base_path / Path("deployment_tools/inference_engine/lib/intel64/myriad_compile")
-        self.model_zoo_path = self.base_path / Path("deployment_tools/open_model_zoo/models")
+
+        self.model_zoo_type = request.form.get('zoo_type', "intel")
+        if self.model_zoo_type == "intel":
+            self.model_zoo_path = self.base_path / Path("deployment_tools/open_model_zoo/models")
+        elif self.model_zoo_type == "depthai":
+            self.model_zoo_path = Path(__file__).parent / Path("depthai-model-zoo/models")
+        else:
+            raise ValueError(f'Unknown zoo name: "{self.model_zoo_type}", available: "intel", "depthai"')
 
         self.env = os.environ.copy()
         self.env['InferenceEngine_DIR'] = str(self.base_path / Path("deployment_tools/inference_engine/share"))
@@ -187,17 +194,17 @@ def parse_config(config_path, name, data_type, env):
         if "source" not in file:
             raise BadRequest("Each file needs to have \"source\" param")
         if "$type" in file["source"]:
-            if file["source"]["$type"] == "http":
+            if file["source"]["$type"] == "http" and "$REQUEST" in file["source"]["url"]:
                 local_path = file["source"]["url"].replace("$REQUEST", str((env.workdir / name / data_type).absolute()))
                 file["source"]["url"] = "file://" + local_path
-            if "size" not in file:
-                if file["source"]["$type"] != "http" or not file["source"]["url"].startswith("file://"):
-                    raise BadRequest("You need to supply \"size\" parameter for file when using a remote source")
-                file["size"] = Path(local_path).stat().st_size
-            if "sha256" not in file:
-                if file["source"]["$type"] != "http" or not file["source"]["url"].startswith("file://"):
-                    raise BadRequest("You need to supply \"sha256\" parameter for file when using a remote source")
-                file["sha256"] = sha256sum(local_path)
+            # if "size" not in file:
+            #     if not file["source"]["url"].startswith("file://"):
+            #         raise BadRequest("You need to supply \"size\" parameter for file when using a remote source")
+            #     file["size"] = Path(local_path).stat().st_size
+            # if "sha256" not in file:
+            #     if not file["source"]["url"].startswith("file://"):
+            #         raise BadRequest("You need to supply \"sha256\" parameter for file when using a remote source")
+            #     file["sha256"] = sha256sum(local_path)
 
     with open(config_path, "w", encoding='utf8') as f:
         yaml.dump(config, f , default_flow_style=False, allow_unicode=True)

--- a/main.py
+++ b/main.py
@@ -293,7 +293,7 @@ def compile():
             f"{env.executable} {env.converter_path} --precisions {data_type} --output_dir {env.workdir} --download_dir {env.workdir} --name {name} --model_root {env.workdir}"
         )
 
-    xml_path = next(env.workdir.rglob(f"**/{name}.xml"), None)
+    xml_path = env.workdir / name / (name + ".xml")
     out_path = xml_path.with_suffix('.blob')
     out_path.parent.mkdir(parents=True, exist_ok=True)
     commands.append(f"{env.compiler_path} -m {xml_path} -o {out_path} -c {compile_config_path} {myriad_params_advanced}")

--- a/model_compiler/openvino_2021.4/src/open_model_zoo/model_tools/_configuration.py
+++ b/model_compiler/openvino_2021.4/src/open_model_zoo/model_tools/_configuration.py
@@ -340,7 +340,7 @@ class Model:
                                 p, file.name, _common.KNOWN_PRECISIONS))
                     files_per_precision.setdefault(p, set()).add(file.name.parts[1])
 
-                print(files_per_precision)
+                print(list(files_per_precision.items()))  # ["{'FP16': {'megadepth_192x256.bin', 'megadepth_192x256.xml'}}", '']
                 for precision, precision_files in files_per_precision.items():
                     for ext in ['xml', 'bin']:
                         if (name + '.' + ext) not in precision_files:

--- a/model_compiler/openvino_2021.4/src/open_model_zoo/model_tools/_configuration.py
+++ b/model_compiler/openvino_2021.4/src/open_model_zoo/model_tools/_configuration.py
@@ -340,7 +340,6 @@ class Model:
                                 p, file.name, _common.KNOWN_PRECISIONS))
                     files_per_precision.setdefault(p, set()).add(file.name.parts[1])
 
-                print(list(files_per_precision.items()))  # ["{'FP16': {'megadepth_192x256.bin', 'megadepth_192x256.xml'}}", '']
                 for precision, precision_files in files_per_precision.items():
                     for ext in ['xml', 'bin']:
                         if (name + '.' + ext) not in precision_files:

--- a/model_compiler/openvino_2021.4/src/open_model_zoo/model_tools/_configuration.py
+++ b/model_compiler/openvino_2021.4/src/open_model_zoo/model_tools/_configuration.py
@@ -340,6 +340,7 @@ class Model:
                                 p, file.name, _common.KNOWN_PRECISIONS))
                     files_per_precision.setdefault(p, set()).add(file.name.parts[1])
 
+                print(files_per_precision)
                 for precision, precision_files in files_per_precision.items():
                     for ext in ['xml', 'bin']:
                         if (name + '.' + ext) not in precision_files:

--- a/setup_container.py
+++ b/setup_container.py
@@ -9,6 +9,9 @@ versions = {
     "2021_2": Path("/opt/intel/openvino2021_2"),
     "2021_1": Path("/opt/intel/openvino2021_1"),
     "2020_4": Path("/opt/intel/openvino2020_4"),
+}
+
+legacy = {
     "2020_3": Path("/opt/intel/openvino2020_3"),
     "2020_2": Path("/opt/intel/openvino2020_2"),
     "2020_1": Path("/opt/intel/openvino2020_1"),
@@ -22,7 +25,7 @@ def abs_str(path: Path):
     return str(path.absolute())
 
 
-def create_venv(name: str, path: Path):
+def create_venv(name: str, path: Path, interpreter):
     req_path = path / "deployment_tools" / "model_optimizer" / "requirements.txt"
     venv_path = Path("/app") / "venvs" / ("venv"+name)
     venv_python_path = venv_path / "bin" / "python"
@@ -32,7 +35,7 @@ def create_venv(name: str, path: Path):
         del new_env["PYTHONHOME"]
     new_env["VIRTUAL_ENV"] = abs_str(venv_path)
     new_env["PATH"] = abs_str(venv_path / "bin") + ":" + new_env["PATH"]
-    subprocess.check_call([sys.executable, "-m", "venv", abs_str(venv_path)])
+    subprocess.check_call([interpreter, "-m", "venv", abs_str(venv_path)])
     subprocess.check_call([abs_str(venv_python_path), "-m", "pip", "install", "-U", "pip"], env=new_env)
     subprocess.check_call([abs_str(venv_python_path), "-m", "pip", "install", "-r", abs_str(req_path)], env=new_env)
     subprocess.check_call([abs_str(venv_python_path), "-m", "pip", "install", *additional_packages], env=new_env)
@@ -40,5 +43,7 @@ def create_venv(name: str, path: Path):
 
 if __name__ == "__main__":
     for env_name, base_path in versions.items():
-        create_venv(env_name, base_path)
+        create_venv(env_name, base_path, "python3.8")
+    for env_name, base_path in legacy.items():
+        create_venv(env_name, base_path, "python3.7")
 


### PR DESCRIPTION
This PR introduces the ability to download models from [depthai-model-zoo](https://github.com/luxonis/depthai-model-zoo) and allows to specify the conversion files via URL - this however requires to specify both file size and its SHA265.

Example usage:

```python
result = blobconverter.from_zoo(name="megadepth", zoo_type="depthai")

result = blobconverter.from_openvino(
    xml="https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml",
    xml_size=31526,
    xml_sha256="54d62ce4a3c3d7f1559a22ee9524bac41101103a8dceaabec537181995eda655",
    bin="https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin",
    bin_size=4276038,
    bin_sha256="3586df5340e9fcd73ba0e2d802631bd9e027179490635c03b273d33d582e2b58"
)
```