### PR TITLE
Fixing compiler_params

### DIFF
--- a/cli/blobconverter/__init__.py
+++ b/cli/blobconverter/__init__.py
@@ -526,7 +526,7 @@ def __run_cli__():
     parser.add_argument('-o', '--output-dir', help="Directory where the output blob should be saved")
     parser.add_argument('-v', '--version', choices=[Versions.v2021_2, Versions.v2021_3, Versions.v2021_4, Versions.v2022_1, Versions.v2022_3_RVC3], help=f"OpenVINO version to use for conversion. To export model for RVC3, you must set OpenVINO version to '{Versions.v2022_3_RVC3}'.")
     parser.add_argument('--optimizer-params', help="Additional params to use when converting a model to OpenVINO IR")
-    parser.add_argument('--compile-params', help="Additional params to use when compiling a model to MyriadX blob")
+    parser.add_argument('--compile-params', nargs="+", help="Additional params to use when compiling a model to MyriadX blob")
     parser.add_argument('--converter-url', dest="url", help="URL to BlobConverter API endpoint used for conversion")
     parser.add_argument('--no-cache', dest="use_cache", action="store_false", help="Omit .cache directory and force new compilation of the blob")
     parser.add_argument('--dry', dest="dry", action="store_true", help="Instead of compiling the blob, return compilation commands (for manual conversion)")


### PR DESCRIPTION
Added `nargs="+" `option to argparser to interpret `--compile-params` as list and not as string. 
This way, the `"myriad_params_advanced": ' '.join(compile_params)` works as expected. 

Same can be done for optimizer_params.

The blobconverter is now called using:
```
python3 -m blobconverter -zn MODEL -zt depthai -sh 6 --compile-params "-ip FP16" "-foo bar" --rest-of-the-args ...
```

EDIT:
```
python3 -m blobconverter -zn MODEL -zt depthai -sh 6 --compile-params "-ip FP16 -foo bar" --rest-of-the-args ...
```
^ seems to work as well
